### PR TITLE
start introducing XState for state management (delicious dog food!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ More than simply inspiration, the starting point for this project is David Khour
 - [ ] add ability to load examples as presets for exploration
 - [ ] add mock API functionality for asynchronous event
 - [ ] create two-way statechart changes based on UI interaction
+- [ ] implement the PWA pattern so the visualizer can be used in no and limited bandwidth circumstances
 - [ ] create an Electron app for even more local visualization
 - [ ] add Travis CI and Coveralls testing

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { StateChart } from './components/StateChart'
 import { Layout } from './components/Layout'
+import { RootProvider } from './machines/Root'
 
 const rawDefaultMachineText = require('./sampleMachines/defaultMachine.js.txt')
 
@@ -8,8 +9,10 @@ const defaultMachine = Object.values(rawDefaultMachineText).join('')
 
 export const App = () => {
   return (
-    <Layout>
-      <StateChart machine={defaultMachine} height={'calc(100vh - 70px)'} />
-    </Layout>
+    <RootProvider>
+      <Layout>
+        <StateChart machine={defaultMachine} height={'calc(100vh - 70px)'} />
+      </Layout>
+    </RootProvider>
   )
 }

--- a/src/components/StateChart/index.tsx
+++ b/src/components/StateChart/index.tsx
@@ -214,12 +214,7 @@ export class StateChart extends React.Component<
               )
             })}
           </StyledViewTabs>
-          <ToolPanel
-            view={this.state.view}
-            current={this.state.current}
-            code={this.state.code}
-            updateCode={this.updateCode}
-          />
+          <ToolPanel view={this.state.view} current={this.state.current} />
           <footer>
             <button onClick={() => this.updateMachine()}>Update</button>
           </footer>

--- a/src/components/ToolPanel/Editor/index.tsx
+++ b/src/components/ToolPanel/Editor/index.tsx
@@ -2,25 +2,23 @@ import * as React from 'react'
 import AceEditor from 'react-ace'
 import 'brace/theme/monokai'
 import 'brace/mode/typescript'
+import { RootConsumer, updateCode } from 'src/machines/Root'
 
-interface Props {
-  updateCode: (value: string) => void
-  code: string
-}
-
-export const Editor = (props: Props) => {
-  const { code, updateCode } = props
-
+export const Editor = () => {
   return (
-    <AceEditor
-      mode="typescript"
-      theme="monokai"
-      editorProps={{ $blockScrolling: true }}
-      value={code}
-      onChange={value => updateCode(value)}
-      setOptions={{ tabSize: 2 }}
-      width="100%"
-      height="100%"
-    />
+    <RootConsumer>
+      {({ code }) => (
+        <AceEditor
+          mode="typescript"
+          theme="monokai"
+          editorProps={{ $blockScrolling: true }}
+          value={code}
+          onChange={value => updateCode(value)}
+          setOptions={{ tabSize: 2 }}
+          width="100%"
+          height="100%"
+        />
+      )}
+    </RootConsumer>
   )
 }

--- a/src/components/ToolPanel/index.tsx
+++ b/src/components/ToolPanel/index.tsx
@@ -6,8 +6,6 @@ import { Editor } from './Editor'
 interface Props {
   view: string
   current: State<any, any>
-  code: string
-  updateCode: (code: string) => void
 }
 
 const StyledField = styled.div`
@@ -33,11 +31,11 @@ function Field({ label, children }: FieldProps) {
 }
 
 export const ToolPanel = (props: Props) => {
-  const { view, current, code, updateCode } = props
+  const { view, current } = props
 
   switch (view) {
     case 'definition':
-      return <Editor code={code} updateCode={updateCode} />
+      return <Editor />
     case 'state':
       return (
         <div>

--- a/src/machines/Root.tsx
+++ b/src/machines/Root.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react'
+import {
+  interpret,
+  Machine,
+  assign,
+  StateNode,
+  MachineConfig,
+  MachineOptions,
+} from 'xstate'
+import { toMachine } from 'src/lib/utils'
+
+enum RootMachineEvents {
+  UpdateCode = 'UPDATE_CODE',
+}
+
+interface RootMachineStateSchema {
+  states: {
+    loading: {}
+    ready: {}
+    valid: {}
+    invalid: {}
+  }
+}
+
+type RootMachineEvent = { type: RootMachineEvents.UpdateCode; data: string }
+
+interface RootMachineContext {
+  code: string
+}
+const getMachines = () =>
+  new Promise((fulfilled, rejected) => {
+    try {
+      const serializedMachines = localStorage.getItem('machines')
+      const machines = JSON.parse(serializedMachines || '{}')
+      fulfilled(machines)
+    } catch (error) {
+      rejected(error)
+    }
+  })
+
+const rootMachineConfig: MachineConfig<
+  RootMachineContext,
+  RootMachineStateSchema,
+  RootMachineEvent
+> = {
+  id: 'app',
+  context: {
+    code: '',
+  },
+  initial: 'loading',
+  states: {
+    loading: {
+      invoke: {
+        src: 'getMachines',
+        onDone: {
+          target: 'ready',
+          actions: [
+            (context: RootMachineContext, event: any) => {
+              // TODO clearly need something here
+            },
+          ],
+        },
+      },
+    },
+    ready: {
+      on: {
+        UPDATE_CODE: {
+          actions: [
+            assign({
+              code: (
+                context: RootMachineContext,
+                // TODO HACK we need typing for events where we can pass it a specific type of event so we don't use any here
+                event: any
+              ) => {
+                console.log(context, event)
+                try {
+                  const isMachine = toMachine(event.data) instanceof StateNode
+                } catch (error) {
+                  console.info('invalid')
+                }
+                return event.data
+              },
+            }),
+          ],
+        },
+      },
+    },
+    valid: {},
+    invalid: {},
+  },
+}
+
+const rootMachineOptions: MachineOptions<
+  RootMachineContext,
+  RootMachineEvent
+> = {
+  services: {
+    getMachines,
+  },
+}
+
+const RootMachine = Machine<
+  RootMachineContext,
+  RootMachineStateSchema,
+  RootMachineEvent
+>(rootMachineConfig, rootMachineOptions)
+
+const rootMachineService = interpret(RootMachine).start()
+
+export const updateCode = (updatedCode: string) =>
+  rootMachineService.send({
+    type: RootMachineEvents.UpdateCode,
+    data: updatedCode,
+  })
+
+const RootContext = React.createContext(RootMachine.initialState.context)
+
+export const RootConsumer = RootContext.Consumer
+
+interface Props {
+  children: React.ReactNode
+}
+
+export const RootProvider = (props: Props) => {
+  const [state, setState] = React.useState(
+    rootMachineService.initialState.context
+  )
+  rootMachineService.onTransition(({ context }) => {
+    setState(context)
+  })
+
+  return (
+    <RootContext.Provider value={state}>{props.children}</RootContext.Provider>
+  )
+}


### PR DESCRIPTION
add TODO about PWA support
add trivial/naive Root machine with corresponding provider
connect Editor to machine instead of passing props from ToolPanel (and StateChart as the antecedent)
add RootProvider to App