### PR TITLE
handle machine code separately from editor code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ More than simply inspiration, the starting point for this project is David Khour
 
 ## Current feature wish list
 
+- [ ] add versioning strategy for statecharts
+- [ ] add cloud storage system (this needs some thought)
 - [ ] render children machines
-- [X] handle TypeScript compilation
+- [x] handle TypeScript compilation
 - [ ] provide "dark mode" setting
 - [ ] use localStorage to persist statechart(s)
 - [ ] add ability to load examples as presets for exploration
@@ -26,4 +28,4 @@ More than simply inspiration, the starting point for this project is David Khour
 - [ ] create two-way statechart changes based on UI interaction
 - [ ] implement the PWA pattern so the visualizer can be used in no and limited bandwidth circumstances
 - [ ] create an Electron app for even more local visualization
-- [X] add Travis CI and Coveralls testing
+- [x] add Travis CI and Coveralls testing

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,9 @@ const defaultMachine = rawDefaultMachineText.default
 const WrappedApp = () => {
   const rootContext = useContext(RootContext)
   // TODO HACK eliminate the failover on the next line
-  const machine = rootContext.code ? rootContext.code : defaultMachine
+  const machine = rootContext.machineCode
+    ? rootContext.machineCode
+    : defaultMachine
 
   return (
     <RootProvider>

--- a/src/components/StateChart/StateChartNode/index.tsx
+++ b/src/components/StateChart/StateChartNode/index.tsx
@@ -249,7 +249,9 @@ export const StateChartNode = (props: StateChartNodeProps) => {
       </StyledStateNodeHeader>
       <StyledStateNodeActions>
         {stateNode.definition.onEntry.map(action => {
-          const actionString = JSON.stringify(action)
+          const actionString = action.type
+            ? action.type
+            : JSON.stringify(action)
           return (
             <StyledStateNodeAction key={actionString} data-action-type="entry">
               {actionString}
@@ -290,7 +292,9 @@ export const StateChartNode = (props: StateChartNodeProps) => {
               </StyledEventButton>
               {transition.cond && <div>{condToString(transition.cond)}</div>}
               {transition.actions.map((action, i) => {
-                const actionString = JSON.stringify(action)
+                const actionString = action.type
+                  ? action.type
+                  : JSON.stringify(action)
                 return (
                   <StyledTransitionAction key={actionString + ':' + i}>
                     {actionString}

--- a/src/components/ToolPanel/Editor/index.tsx
+++ b/src/components/ToolPanel/Editor/index.tsx
@@ -13,7 +13,7 @@ export const Editor = () => {
       mode="typescript"
       theme="monokai"
       editorProps={{ $blockScrolling: true }}
-      value={rootContext.code}
+      value={rootContext.editorCode}
       onChange={value => updateCode(value)}
       setOptions={{ tabSize: 2 }}
       width="100%"

--- a/src/machines/Root.spec.tsx
+++ b/src/machines/Root.spec.tsx
@@ -6,6 +6,7 @@ jest.mock(
   () => 'mocked default code'
 )
 
+// TODO check machineCode values in tests
 const testSuccessfulRootMachine = RootMachine.withConfig({
   services: {
     getMachines: () =>
@@ -29,7 +30,7 @@ describe('RootMachine', () => {
     interpret(testSuccessfulRootMachine)
       .onTransition(state => {
         if (state.matches('loading')) {
-          expect(state.context.code).toBe('')
+          expect(state.context.editorCode).toBe('')
           done()
         }
       })
@@ -40,7 +41,7 @@ describe('RootMachine', () => {
     interpret(testSuccessfulRootMachine)
       .onTransition(state => {
         if (state.matches('ready')) {
-          expect(state.context.code).toBe('some code')
+          expect(state.context.editorCode).toBe('some code')
           done()
         }
       })
@@ -51,7 +52,7 @@ describe('RootMachine', () => {
     interpret(testFailedRootMachine)
       .onTransition(state => {
         if (state.matches('ready')) {
-          expect(state.context.code).toBe('mocked default code')
+          expect(state.context.editorCode).toBe('mocked default code')
           done()
         }
       })


### PR DESCRIPTION
add some future feature ideas to README.md
reference editorCode in Editor
set machineCode in Root machine only if editorCode is valid
update Root machine test
split code context property to editorCode and machineCode
change actionString handling in StateChartNode to show the type