### PR TITLE
state management improvements, minor UI changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "fsms",
     "khourshid",
     "monokai",
+    "resizer",
     "scxml",
     "statechart",
     "transpiled",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4803,6 +4803,31 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
       "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-split-pane": {
+      "version": "0.1.85",
+      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.85.tgz",
+      "integrity": "sha512-3GhaYs6+eVNrewgN4eQKJoNMQ4pcegNMTMhR5bO/NFO91K6/98qdD1sCuWPpsefCjzxNTjkvVYWQC0bMaC45mA==",
+      "requires": {
+        "prop-types": "^15.5.10",
+        "react": "^16.6.3",
+        "react-dom": "^16.6.3",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-style-proptype": "^3.0.0"
+      }
+    },
+    "react-style-proptype": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.2.tgz",
+      "integrity": "sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==",
+      "requires": {
+        "prop-types": "^15.5.4"
+      }
+    },
     "react-test-renderer": {
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^16.8.1",
     "react-ace": "^6.4.0",
     "react-dom": "^16.8.1",
+    "react-split-pane": "^0.1.85",
     "styled-components": "^4.1.3",
     "xstate": "^4.3.1"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,32 +2,33 @@ import * as React from 'react'
 import { useContext } from 'react'
 import { StateChart } from './components/StateChart'
 import { Layout } from './components/Layout'
-import { RootProvider, RootContext } from './machines/Root'
+import { AppProvider, AppContext } from './machines/App/provider'
+import { rootMachineService } from './machines/Root'
+
+rootMachineService.start()
 
 // TODO HACK we shouldn't need to bring in the defaultMachine here
 import * as rawDefaultMachineText from './sampleMachines/defaultMachine.js.txt'
 const defaultMachine = rawDefaultMachineText.default
 
 const WrappedApp = () => {
-  const rootContext = useContext(RootContext)
+  const appContext = useContext(AppContext)
   // TODO HACK eliminate the failover on the next line
-  const machine = rootContext.machineCode
-    ? rootContext.machineCode
+  const machine = appContext.machineCode
+    ? appContext.machineCode
     : defaultMachine
 
   return (
-    <RootProvider>
-      <Layout>
-        <StateChart machine={machine} height={'calc(100vh - 70px)'} />
-      </Layout>
-    </RootProvider>
+    <Layout>
+      <StateChart machine={machine} height={'calc(100vh - 70px)'} />
+    </Layout>
   )
 }
 
 export const App = () => {
   return (
-    <RootProvider>
+    <AppProvider>
       <WrappedApp />
-    </RootProvider>
+    </AppProvider>
   )
 }

--- a/src/components/Layout/Header/__snapshots__/index.spec.tsx.snap
+++ b/src/components/Layout/Header/__snapshots__/index.spec.tsx.snap
@@ -2,12 +2,18 @@
 
 exports[`Header renders correctly 1`] = `
 <div
-  className="sc-bdVaJa hFffZV"
+  className="sc-bdVaJa cqMTxD"
 >
   <p
     className="sc-bwzfXH iJxcRz"
   >
     XState Cartographer
   </p>
+  <button
+    className="sc-htpNat cZppGo"
+    onClick={[Function]}
+  >
+    Update Chart
+  </button>
 </div>
 `;

--- a/src/components/Layout/Header/index.spec.tsx
+++ b/src/components/Layout/Header/index.spec.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Header } from '.'
 
+jest.mock('src/sampleMachines/defaultMachine.js.txt', () => {})
+
 describe('Header', () => {
   it('renders correctly', () => {
     const header = TestRenderer.create(<Header />).toJSON()

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react'
 import styled from 'styled-components'
+import { updateStateChart } from 'src/machines/App/provider'
 
 const HeaderContainer = styled.div`
   display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   background-color: #eaeaea;
   padding: 0;
   margin: 0;
@@ -15,10 +18,17 @@ const HeaderText = styled.p`
   margin-left: 20px;
 `
 
+const Button = styled.button`
+  margin-right: 20px;
+  height: 20px;
+  align-self: center;
+`
+
 export const Header = () => {
   return (
     <HeaderContainer>
       <HeaderText>XState Cartographer</HeaderText>
+      <Button onClick={updateStateChart}>Update Chart</Button>
     </HeaderContainer>
   )
 }

--- a/src/components/StateChart/index.tsx
+++ b/src/components/StateChart/index.tsx
@@ -7,23 +7,7 @@ import { StateChartNode } from './StateChartNode'
 import { ToolPanel } from '../ToolPanel'
 import { toMachine } from 'src/lib/utils'
 import { SVGElement } from './SVGElement'
-
-const StyledViewTabs = styled.ul`
-  display: flex;
-  width: 100%;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: stretch;
-  margin: 0;
-  padding: 0;
-  height: 1rem;
-
-  > li {
-    padding: 0 0.5rem;
-    text-align: center;
-    list-style: none;
-  }
-`
+import SplitPane from 'react-split-pane'
 
 const StyledStateChart = styled.div`
   display: grid;
@@ -171,53 +155,56 @@ export class StateChart extends React.Component<
           '--radius': '0.2rem',
         }}
       >
-        <StyledVisualization>
-          <StateChartNode
-            stateNode={this.state.machine}
-            current={current}
-            preview={preview}
-            onEvent={this.service.send.bind(this)}
-            onPreEvent={event =>
-              this.setState({
-                preview: this.service.nextState(event),
-                previewEvent: event,
-              })
-            }
-            onToggle={id => this.toggleState(id)}
-            onExitPreEvent={() =>
-              this.setState({ preview: undefined, previewEvent: undefined })
-            }
-            toggledStates={this.state.toggledStates}
-            toggled={true}
-          />
-          <SVGElement
-            edges={edges}
-            previewEvent={previewEvent}
-            current={current}
-            preview={preview}
-          />
-        </StyledVisualization>
-        <div
-          style={{
-            overflow: 'scroll',
-            display: 'flex',
-            flexDirection: 'column',
+        <SplitPane
+          split="vertical"
+          minSize={350}
+          primary="second"
+          onDragFinished={() => this.setState({})}
+          resizerStyle={{
+            backgroundColor: '#000',
+            width: 11,
+            cursor: 'ew-resize',
           }}
         >
-          <StyledViewTabs>
-            {['definition', 'state'].map(view => {
-              return (
-                <li onClick={() => this.setState({ view })} key={view}>
-                  {view}
-                </li>
-              )
-            })}
-          </StyledViewTabs>
+          <StyledVisualization>
+            <StateChartNode
+              stateNode={this.state.machine}
+              current={current}
+              preview={preview}
+              onEvent={this.service.send.bind(this)}
+              onPreEvent={event =>
+                this.setState({
+                  preview: this.service.nextState(event),
+                  previewEvent: event,
+                })
+              }
+              onToggle={id => this.toggleState(id)}
+              onExitPreEvent={() =>
+                this.setState({ preview: undefined, previewEvent: undefined })
+              }
+              toggledStates={this.state.toggledStates}
+              toggled={true}
+            />
+            <SVGElement
+              edges={edges}
+              previewEvent={previewEvent}
+              current={current}
+              preview={preview}
+            />
+          </StyledVisualization>
+          {/* <div
+            style={{
+              overflow: 'scroll',
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          > */}
           <ToolPanel view={this.state.view} current={this.state.current} />
           <footer>
             <button onClick={() => this.updateMachine()}>Update</button>
           </footer>
-        </div>
+          {/* </div> */}
+        </SplitPane>
       </StyledStateChart>
     )
   }

--- a/src/components/ToolPanel/Editor/index.tsx
+++ b/src/components/ToolPanel/Editor/index.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react'
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import AceEditor from 'react-ace'
 import 'brace/theme/monokai'
 import 'brace/mode/typescript'
-import { RootContext, updateCode } from 'src/machines/Root'
+import { AppContext, updateCode } from 'src/machines/App/provider'
 
 export const Editor = () => {
-  const rootContext = useContext(RootContext)
+  const appContext = useContext(AppContext)
 
   return (
     <AceEditor
       mode="typescript"
       theme="monokai"
       editorProps={{ $blockScrolling: true }}
-      value={rootContext.editorCode}
+      value={appContext.editorCode}
       onChange={value => updateCode(value)}
       setOptions={{ tabSize: 2 }}
       width="100%"

--- a/src/components/ToolPanel/index.tsx
+++ b/src/components/ToolPanel/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useState } from 'react'
 import styled from 'styled-components'
 import { State } from 'xstate'
 import { Editor } from './Editor'
@@ -7,6 +8,23 @@ interface Props {
   view: string
   current: State<any, any>
 }
+
+const StyledViewTabs = styled.ul`
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: stretch;
+  margin: 0;
+  padding: 0;
+  height: 1rem;
+
+  > li {
+    padding: 0 0.5rem;
+    text-align: center;
+    list-style: none;
+  }
+`
 
 const StyledField = styled.div`
   > label {
@@ -30,9 +48,13 @@ function Field({ label, children }: FieldProps) {
   )
 }
 
-export const ToolPanel = (props: Props) => {
-  const { view, current } = props
+interface SelectedViewProps {
+  view: string
+  current: any
+}
 
+const SelectedView = (props: SelectedViewProps) => {
+  const { current, view } = props
   switch (view) {
     case 'definition':
       return <Editor />
@@ -65,4 +87,24 @@ export const ToolPanel = (props: Props) => {
     default:
       return null
   }
+}
+
+export const ToolPanel = (props: Props) => {
+  const { /*view,*/ current } = props
+  const [activeView, setView] = useState('definition')
+
+  return (
+    <React.Fragment>
+      <StyledViewTabs>
+        {['definition', 'state'].map(view => {
+          return (
+            <li onClick={() => setView(view)} key={view}>
+              {view}
+            </li>
+          )
+        })}
+      </StyledViewTabs>
+      <SelectedView view={activeView} current={current} />
+    </React.Fragment>
+  )
 }

--- a/src/machines/App/App.spec.tsx
+++ b/src/machines/App/App.spec.tsx
@@ -1,4 +1,4 @@
-import { RootMachine } from './Root'
+import { AppMachine } from '.'
 import { interpret } from 'xstate'
 
 jest.mock(
@@ -7,7 +7,7 @@ jest.mock(
 )
 
 // TODO check machineCode values in tests
-const testSuccessfulRootMachine = RootMachine.withConfig({
+const testSuccessfulRootMachine = AppMachine.withConfig({
   services: {
     getMachines: () =>
       new Promise((fulfilled, rejected) => {
@@ -16,7 +16,7 @@ const testSuccessfulRootMachine = RootMachine.withConfig({
   },
 })
 
-const testFailedRootMachine = RootMachine.withConfig({
+const testFailedRootMachine = AppMachine.withConfig({
   services: {
     getMachines: () =>
       new Promise((fulfilled, rejected) => {
@@ -31,6 +31,7 @@ describe('RootMachine', () => {
       .onTransition(state => {
         if (state.matches('loading')) {
           expect(state.context.editorCode).toBe('')
+          expect(state.context.machineCode).toBe('')
           done()
         }
       })
@@ -42,6 +43,7 @@ describe('RootMachine', () => {
       .onTransition(state => {
         if (state.matches('ready')) {
           expect(state.context.editorCode).toBe('some code')
+          expect(state.context.machineCode).toBe('some code')
           done()
         }
       })
@@ -53,6 +55,7 @@ describe('RootMachine', () => {
       .onTransition(state => {
         if (state.matches('ready')) {
           expect(state.context.editorCode).toBe('mocked default code')
+          expect(state.context.machineCode).toBe('mocked default code')
           done()
         }
       })

--- a/src/machines/App/provider.tsx
+++ b/src/machines/App/provider.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+import { appMachineService, AppMachine, AppMachineEvents } from '.'
+
+export const updateCode = (updatedCode: string) =>
+  appMachineService.send({
+    type: AppMachineEvents.UpdateCode,
+    data: updatedCode,
+  })
+
+export const updateStateChart = () =>
+  appMachineService.send({
+    type: AppMachineEvents.UpdateStateChart,
+  })
+
+export const AppContext = React.createContext(AppMachine.initialState.context)
+
+interface Props {
+  children: React.ReactNode
+}
+
+export const AppProvider = (props: Props) => {
+  const [state, setState] = React.useState(AppMachine.initialState.context)
+  appMachineService.onTransition(newState => {
+    console.log(newState)
+    setState(newState.context)
+  })
+
+  return (
+    <AppContext.Provider value={state}>{props.children}</AppContext.Provider>
+  )
+}

--- a/src/machines/Root.ts
+++ b/src/machines/Root.ts
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import { interpret, Machine, MachineConfig, MachineOptions } from 'xstate'
+import { ToolPanelMachine } from './ToolPanel'
+import { AppMachine } from './App'
+
+interface RootMachineContext {}
+
+interface RootMachineStateSchema {
+  states: {
+    toolPanel: {}
+    app: {}
+  }
+}
+
+type RootMachineEvent = { type: 'none' }
+
+const rootMachineConfig: MachineConfig<
+  RootMachineContext,
+  RootMachineStateSchema,
+  RootMachineEvent
+> = {
+  id: 'root',
+  type: 'parallel',
+  states: {
+    toolPanel: {
+      invoke: {
+        src: 'toolPanelMachine',
+      },
+    },
+    app: {
+      invoke: {
+        src: 'appMachine',
+      },
+    },
+  },
+}
+
+const rootMachineOptions: MachineOptions<
+  RootMachineContext,
+  RootMachineEvent
+> = {
+  services: {
+    appMachine: AppMachine,
+    toolPanelMachine: ToolPanelMachine,
+  },
+}
+
+export const RootMachine = Machine<
+  RootMachineContext,
+  RootMachineStateSchema,
+  RootMachineEvent
+>(rootMachineConfig, rootMachineOptions)
+
+export const rootMachineService = interpret(RootMachine)

--- a/src/machines/ToolPanel/index.ts
+++ b/src/machines/ToolPanel/index.ts
@@ -1,0 +1,49 @@
+import { Machine, MachineConfig, interpret } from 'xstate'
+
+export enum ToolPanelMachineEvents {
+  ShowDefinition = 'SHOW_DEFINITION',
+  ShowState = 'SHOW_STATE',
+}
+
+interface ToolPanelMachineStateSchema {
+  states: {
+    definition: {}
+    state: {}
+  }
+}
+
+type ToolPanelMachineEvent =
+  | { type: ToolPanelMachineEvents.ShowDefinition }
+  | { type: ToolPanelMachineEvents.ShowState }
+
+interface ToolPanelMachineContext {}
+
+const toolPanelMachineConfig: MachineConfig<
+  ToolPanelMachineContext,
+  ToolPanelMachineStateSchema,
+  ToolPanelMachineEvent
+> = {
+  id: 'toolPanel',
+  context: {},
+  initial: 'definition',
+  states: {
+    definition: {
+      on: {
+        [ToolPanelMachineEvents.ShowState]: 'state',
+      },
+    },
+    state: {
+      on: {
+        [ToolPanelMachineEvents.ShowDefinition]: 'definition',
+      },
+    },
+  },
+}
+
+export const ToolPanelMachine = Machine<
+  ToolPanelMachineContext,
+  ToolPanelMachineStateSchema,
+  ToolPanelMachineEvent
+>(toolPanelMachineConfig)
+
+export const toolPanelMachineService = interpret(ToolPanelMachine).start()

--- a/src/machines/ToolPanel/provider.tsx
+++ b/src/machines/ToolPanel/provider.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import {
+  toolPanelMachineService,
+  ToolPanelMachine,
+  ToolPanelMachineEvents,
+} from '.'
+
+// TODO make the mode an enum and reference it in state names as well
+export const toggleToolPanel = (mode: string) => {
+  switch (mode) {
+    case 'definition':
+      toolPanelMachineService.send({
+        type: ToolPanelMachineEvents.ShowDefinition,
+      })
+    case 'state':
+      toolPanelMachineService.send({
+        type: ToolPanelMachineEvents.ShowState,
+      })
+  }
+}
+
+export const ToolPanelContext = React.createContext(
+  ToolPanelMachine.initialState.context
+)
+
+interface Props {
+  children: React.ReactNode
+}
+
+export const ToolPanelProvider = (props: Props) => {
+  const [state, setState] = React.useState(
+    ToolPanelMachine.initialState.context
+  )
+
+  toolPanelMachineService.onTransition(newState => {
+    console.log(newState)
+    setState(newState.context)
+  })
+
+  return (
+    <ToolPanelContext.Provider value={state}>
+      {props.children}
+    </ToolPanelContext.Provider>
+  )
+}


### PR DESCRIPTION
move "Update" button to header
add react-split-pane for more viewing flexibility
add ToolPanel and App child machines from Root
make Root machine a represent the parallel top-level state
refactor React component provider code out of machine files
move ToolPanel tabs from StateChart to ToolPanel
update test snapshot for Header (since we added the button)
eliminate duplicated RootProvider from App